### PR TITLE
Refactor pod for all namespaces

### DIFF
--- a/src/app/dashboard/cluster/[clusterId]/ClusterInfo.jsx
+++ b/src/app/dashboard/cluster/[clusterId]/ClusterInfo.jsx
@@ -7,7 +7,7 @@ const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 
 async function getData() {
     try {
-        const podsRes = await k8sApi.listNamespacedPod('default');
+        const podsRes = await k8sApi.listPodForAllNamespaces();
         console.log(podsRes.body);
         return podsRes.body;
     } catch (err) {


### PR DESCRIPTION
## Issue Type
- [x] Bug
- [ ] Feature
- [ ] Tech Debt

## Description
### Problem Statement
Users can only see pods from namespace `default` which means they cannot see pods from other namespaces if they are not named `default`. Users might have namespaces named something other than `default`

### Solution
Changed namespaces method to list pods for all namespaces rather than just the ones for the 'default' namespace.

## Ticket Item
N/A, quick bug fix

## Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix
1. Go to: http://localhost:3000/dashboard/snapshots
2. Ensure the pods not listed in the 'default' namespace are retrieved successfully.

## Previous Behavior
If the user had pods that weren't in the 'default' namespace, it wouldn't fetch any of the pods.

## Expected Behavior
It will now fetch pods for all namespaces rather than just the 'default' namespace.

## Screenshots & Videos
N/A

## Additional Context
N/A