### PR TITLE
RS/THT-12/AWS download cache

### DIFF
--- a/src/app/dashboard/cluster/[clusterId]/snapshots/[fileKey]/page.tsx
+++ b/src/app/dashboard/cluster/[clusterId]/snapshots/[fileKey]/page.tsx
@@ -1,9 +1,15 @@
 import {downloadFromS3} from "@/services/aws-s3-service.ts";
 import "highlight.js/styles/atom-one-dark.css";
 import YamlDisplay from "@/app/dashboard/cluster/[clusterId]/snapshots/[fileKey]/YamlDisplay.tsx";
+import { cache } from "react";
 
+export const revalidate = 3600 // revalidate at most every hour
 export default async function SnapshotFilePage({params}) {
-  const fileString = await downloadFromS3(params.fileKey);
+  // The React cache function is used to memoize data requests.
+  const getFileString = cache(async (fileKey: string) => {
+    return await downloadFromS3(fileKey)
+  });
+  const fileString = await getFileString(params.fileKey);
   return (
     <div>
       <YamlDisplay fileString={fileString}/>


### PR DESCRIPTION
## Issue Type
- [ ] Bug
- [X] Feature
- [ ] Tech Debt

## Description
Added caching for files retrieved from s3.

## Ticket Item
N/A, but may be related to THT-12 Retrieve and view multiple snapshots from AWS

## Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix
1. Go to http://localhost:3000/dashboard/snapshots
2. Click on a cluster and snapshot to view
3. Navigate to a different page, then go back to the same cluster snapshot you had viewed in Step 2
4. Data should load faster, since it is cached server-side

## Previous Behavior
No cache, file is redownloaded each time on the server from s3.

## Expected Behavior
* Reduced fetch requests to AWS S3
* Faster load of cluster data on 2nd request of a cluster snapshot

## Screenshots & Videos
N/A

## Additional Context
More information on Next.js Caching: https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#fetching-data-on-the-server-with-third-party-libraries
