### PR TITLE
NC/Grafana Implementation (Cluster Metrics Visualization)

### DIFF
--- a/src/app/dashboard/metrics/page.tsx
+++ b/src/app/dashboard/metrics/page.tsx
@@ -1,0 +1,21 @@
+import { NextPage } from 'next';
+
+/**
+ * Goal for this page: Have a form element for the user to submit their current grafana service URL, which changes every time the grafana
+ * service is deployed. Currently I don't have a way to persist it since the URL changes whenever I spin up minikube and run minikube service grafana-ext
+ * So my mindset was: enter the URL into the form, save that URL, and have multiple iframes prepared so that we can then add that URL to the iframe embed and complete them.
+ */
+
+const Page: NextPage = async () => {
+
+
+  return (
+    <div>
+      <h1>Metrics Visualizer</h1>
+      <p>Welcome to the user page!</p>
+    <iframe src={process.env.GRAFANA_URL} width="1500" height="750" frameBorder="0"></iframe>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/navbar.tsx
+++ b/src/app/navbar.tsx
@@ -23,6 +23,7 @@ export default function Navbar() {
                 <a href="/dashboard/cluster" className="text-gray-500 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-xl font-medium">Clusters</a>
                 <a href="/dashboard/snapshots" className="text-gray-500 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-xl font-medium">Snapshots</a>
                 <a href="/dashboard/backup" className="text-gray-500 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-xl font-medium">Backup</a>
+                <a href="/dashboard/metrics" className="text-gray-500 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-xl font-medium">Metrics</a>
                 <a href="https://github.com/oslabs-beta/TimeKube/" className="text-gray-500 hover:bg-gray-700 hover:text-white rounded-md px-3 py-2 text-xl font-medium">GitHub</a>
               </div>
             </div>
@@ -35,6 +36,7 @@ export default function Navbar() {
           <a href="/dashboard/cluster" className="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">Clusters</a>
           <a href="/dashboard/snapshots" className="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">Snapshots</a>
           <a href="/dashboard/backup" className="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">Backup</a>
+          <a href="/dashboard/metrics" className="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">Clusters</a>
           <a href="https://github.com/oslabs-beta/TimeKube/" className="text-gray-300 hover:bg-gray-700 hover:text-white block rounded-md px-3 py-2 text-base font-medium">GitHub</a>
         </div>
       </div>


### PR DESCRIPTION
## Issue Type
- [ ] Bug
- [x] Feature
- [ ] Tech Debt

## Description
With this feature, users will be able to enter their Grafana URL into their own .env file and have it embedded within the app under the "Metrics" tab.

## Ticket Item

## Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix
1. After setting up the Grafana deployment and proper config, copy the cluster's dashboard URL from the Grafana website.
2. Within the .env file, paste the URL from the first step as the GRAFANA_URL property.
3. Go to localhost:3000/dashboard/metrics
4. The Grafana dashboard will load within the page

## Previous Behavior
N/A

## Expected Behavior
Grafana dashboard will be implemented into the application, allowing for viewers to access their dashboard more easily.

## Screenshots & Videos
![image](https://github.com/oslabs-beta/TimeKube/assets/133680112/506bff02-0d2c-4933-8977-2b229b91b944)


## Additional Context
It is extremely important that the allow_embedding and auth.anonymous properties within grafana's deployment settings are both set to true. Bugs **will** occur if the user attempts to add their URL without changing these properties, as they are set to false by default. The user must also have the Grafana service continuously deployed. Depending on how Grafana is deployed, the URL may change if it is restarted. Make sure that the GRAFANA_URL property in .env always matches the URL given when Grafana is deployed.