### PR TITLE
Initialize database on app startup

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,10 +2,12 @@ import Image from "next/image";
 import Link from "next/link";
 import { startChronJobs } from "@/services/autobackup";
 import OurTeam from "./OurTeam";
+import { initDB } from "@/utils/appdb";
 
 export default function Home() {
   {/**/}
   // startChronJobs()
+  initDB();
   return (
     <main className="flex min-h-screen min flex-col items-center justify-between">
         <div className="w-full flex">


### PR DESCRIPTION
## Issue Type
- [X] Bug
- [ ] Feature
- [ ] Tech Debt

## Description
Local SQLite database was not initialized on first startup of app.

## Ticket Item
N/A

## Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix
### Reproduce Bug
1. Clone the repo
2. `npm install` and `npm run dev`
3. Open the main page of the app and navigate to `/dashboard/snapshots`, where you will be presented with an error.

To validate bugfix, follow these same steps with this branch.

## Previous Behavior
`./appdata/snapshots.db` was being initialized when the tests were run, but not when app was first started. This created a situation where the application would be missing the database if the tests were not run and the database was not automatically initialized.

## Expected Behavior
Upon loading the main page of the app, `./appdata/snapshots.db` will be created if not already existing.

## Screenshots & Videos
### Bug
![image](https://github.com/oslabs-beta/TimeKube/assets/13823341/4a97c3b4-6e30-475c-9d8c-eaad922bf96d)


## Additional Context
N/A